### PR TITLE
Fixed Testing pysat bug, removed TOPS from cloudcatalog notebook

### DIFF
--- a/CloudCatalog_Demo.ipynb
+++ b/CloudCatalog_Demo.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Cloud Catalog Demo (feat. MMS)\n",
     "\n",
-    "The CloudCatalog specification and accompanying Python client and demo notebook are a method for efficiently getting a list of data files stored in AWS S3 that are publicly accessible to scientists. Both data from the NASA public and TOPS (Transform to Open Science) AWS data stores and data that other HelioClouds have made public are equally accessible via this interface.  Currently cloudcatalog lets you access datasets you are aware of, or walk through the public listing of available datasets. \n",
+    "The CloudCatalog specification and accompanying Python client and demo notebook are a method for efficiently getting a list of data files stored in AWS S3 that are publicly accessible to scientists. Both data from the NASA public ODR (Open Data Repository) AWS data stores and data that other HelioClouds have made public are equally accessible via this interface.  Currently cloudcatalog lets you access datasets you are aware of, or walk through the public listing of available datasets. \n",
     "\n",
     "In addition to querying which datasets are available, users can directly retrieve the list of files in the form of 'time, S3 file key, filesize' as a Pandas DataFrame.\n",
     "\n",

--- a/Testing_Notebook.ipynb
+++ b/Testing_Notebook.ipynb
@@ -64,6 +64,7 @@
     "from dask.distributed import Client\n",
     "from dask_gateway import Gateway, GatewayCluster\n",
     "\n",
+    "pysat.params['data_dirs'] = '.'\n",
     "imports_loaded_flag = True\n",
     "debug = False"
    ]


### PR DESCRIPTION
Changed term 'TOPS' to 'ODR' in CloudCatalog_Demo.ipynb to match NASA requirements.

Fixed minor pysat bug (pysat.params['data_dirs'] inconsistently set) in main Testing_Notebook.ipynb
