### PR TITLE
13 bugfix

### DIFF
--- a/01_Testing_Notebook.ipynb
+++ b/01_Testing_Notebook.ipynb
@@ -524,18 +524,7 @@
     "pyspedas.tplot(['mms1_fgm_b_gse_brst_l2', 'mms1_fgm_b_gsm_brst_l2'])\n",
     "gse_data = pyspedas.get_data('mms1_fgm_b_gse_brst_l2')\n",
     "checksum_y = gse_data.y.sum()\n",
-    "print(checksum_y)\n",
     "assert int(checksum_y) == 415662"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0d82fb39-86cb-4240-8262-6415b18a1d74",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "checksum_y"
    ]
   },
   {

--- a/01_Testing_Notebook.ipynb
+++ b/01_Testing_Notebook.ipynb
@@ -183,7 +183,8 @@
     "    debug = True\n",
     "s3name=\"s3://gov-nasa-hdrl-data1/demo-data/mms_fgm.cdf\"\n",
     "with cdflib.CDF(s3name) as cdfin1:\n",
-    "    assert math.isclose(sum(sum(cdfin1['mms1_fgm_b_gse_brst_l2'])), 415662.265625)\n",
+    "    frame = cdfin1['mms1_fgm_b_gse_brst_l2']\n",
+    "    assert int(sum(sum(frame))) == 415662\n",
     "    if debug:\n",
     "        print(cdfin1.cdf_info())\n",
     "\"\"\"\n",
@@ -201,6 +202,7 @@
    "source": [
     "# NetCDF via xarray, using s3fs, reading from S3 cloud\n",
     "if 'imports_loaded_flag' not in locals():\n",
+    "    import math\n",
     "    import s3fs\n",
     "    import xarray as xr\n",
     "    debug = True\n",
@@ -210,7 +212,8 @@
     "dataset = xr.open_dataset(fgrab)\n",
     "if debug:\n",
     "    print(f\"Dimensions = {dataset.dims}\")\n",
-    "assert math.isclose(sum(dataset['DISKCOUNTSDATA_DAY'].data[:,0]),4384917.771728516)\n",
+    "frame = dataset['DISKCOUNTSDATA_DAY'].data[:,0]\n",
+    "assert math.isclose(math.fsum(frame),4384917.771728516)\n",
     "dataset.close()\n",
     "fgrab.close()"
    ]
@@ -520,9 +523,19 @@
     "mms_fgm = pyspedas.projects.mms.fgm(trange=time_range, data_rate='brst')\n",
     "pyspedas.tplot(['mms1_fgm_b_gse_brst_l2', 'mms1_fgm_b_gsm_brst_l2'])\n",
     "gse_data = pyspedas.get_data('mms1_fgm_b_gse_brst_l2')\n",
-    "checksum_y = sum(sum(gse_data.y))\n",
-    "#print(checksum_y)\n",
-    "assert math.isclose(checksum_y,415662.265625)"
+    "checksum_y = gse_data.y.sum()\n",
+    "print(checksum_y)\n",
+    "assert int(checksum_y) == 415662"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d82fb39-86cb-4240-8262-6415b18a1d74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checksum_y"
    ]
   },
   {
@@ -729,34 +742,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6513260e-97b9-42ed-b4cc-cb8e24a53f16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fr=cloudcatalog.CloudCatalog(\"s3://gov-nasa-hdrl-data1/\")\n",
-    "frID = \"aia_0094\"\n",
-    "myjson = fr.get_entry(frID)\n",
-    "start, stop = myjson['start'], myjson['stop']\n",
-    "file_registry1 = fr.request_cloud_catalog(frID, start_date=start, stop_date=stop, overwrite=False)\n",
-    "filelist = file_registry1['datakey'].to_list()\n",
-    "print(len(filelist),start,stop)\n",
-    "s3_files = filelist[0:1000] # small test set to test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e00c35f7-cb35-44a3-8091-70fe9146a1fe",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s3_files = filelist[0:1000] # small test set to test\n",
-    "len(s3_files)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "47624bea-020d-4717-9a83-aebc5e405930",
    "metadata": {},
    "outputs": [],
@@ -859,14 +844,6 @@
    "source": [
     "print(\"Done all tests\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "574b304c-44d3-4357-a966-a5e222b9383f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixed assert()s that were failing due to different precision on summation across numpy/xarray versions. Replaced sum() with math.fsum() or the datatype.sum() options, broadened asserts to allow for numerical differences that do not affect test accuracy.